### PR TITLE
Modifying Axolotl to work on ROCm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,15 +3,15 @@ packaging==23.2
 peft==0.10.0
 transformers @ git+https://github.com/huggingface/transformers.git@43d17c18360ac9c3d3491389328e2fe55fe8f9ce
 tokenizers==0.15.0
-#bitsandbytes==0.43.0
+bitsandbytes==0.43.0
 accelerate==0.28.0
-#deepspeed==0.13.1
+deepspeed==0.13.1
 pydantic==2.6.3
 addict
 fire
 PyYAML>=6.0
 requests
-#datasets==2.15.0
+datasets==2.15.0
 flash-attn==2.5.5
 sentencepiece
 wandb

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,16 +3,16 @@ packaging==23.2
 peft==0.10.0
 transformers @ git+https://github.com/huggingface/transformers.git@43d17c18360ac9c3d3491389328e2fe55fe8f9ce
 tokenizers==0.15.0
-bitsandbytes==0.43.0
-accelerate==0.28.0
-deepspeed==0.13.1
+#bitsandbytes==0.43.0
+#accelerate==0.28.0
+#deepspeed==0.13.1
 pydantic==2.6.3
 addict
 fire
 PyYAML>=6.0
 requests
 datasets==2.15.0
-flash-attn==2.5.5
+#flash-attn==2.5.5
 sentencepiece
 wandb
 einops

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,20 +3,20 @@ packaging==23.2
 peft==0.10.0
 transformers @ git+https://github.com/huggingface/transformers.git@43d17c18360ac9c3d3491389328e2fe55fe8f9ce
 tokenizers==0.15.0
-bitsandbytes==0.43.0
+#bitsandbytes==0.43.0
 accelerate==0.28.0
-deepspeed==0.13.1
+#deepspeed==0.13.1
 pydantic==2.6.3
 addict
 fire
 PyYAML>=6.0
 requests
-datasets==2.15.0
+#datasets==2.15.0
 flash-attn==2.5.5
 sentencepiece
 wandb
 einops
-xformers==0.0.22
+#xformers==0.0.22
 optimum==1.16.2
 hf_transfer
 colorama

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ def parse_requirements():
 
     try:
         if "Darwin" in platform.system():
-            _install_requires.pop(_install_requires.index("xformers==0.0.22"))
+            # _install_requires.pop(_install_requires.index("xformers==0.0.22"))
+            print("hi")
         else:
             torch_version = version("torch")
             _install_requires.append(f"torch=={torch_version}")
@@ -45,9 +46,9 @@ def parse_requirements():
             else:
                 raise ValueError("Invalid version format")
 
-            if (major, minor) >= (2, 1):
-                _install_requires.pop(_install_requires.index("xformers==0.0.22"))
-                _install_requires.append("xformers>=0.0.23")
+            # if (major, minor) >= (2, 1):
+            #     _install_requires.pop(_install_requires.index("xformers==0.0.22"))
+            #     _install_requires.append("xformers>=0.0.23")
     except PackageNotFoundError:
         pass
 

--- a/src/axolotl/monkeypatch/llama_attn_hijack_flash.py
+++ b/src/axolotl/monkeypatch/llama_attn_hijack_flash.py
@@ -22,7 +22,10 @@ from transformers.models.llama.modeling_llama import (
     apply_rotary_pos_emb,
     repeat_kv,
 )
-from xformers.ops import SwiGLU
+# from xformers.ops import SwiGLU
+class SwiGLU:
+    def __init__():
+        print("hi")
 
 from axolotl.monkeypatch.utils import get_cu_seqlens_from_pos_ids, set_module_name
 
@@ -45,15 +48,16 @@ LOG = logging.getLogger("axolotl")
 
 
 def is_xformers_swiglu_available() -> bool:
-    from xformers.ops.common import get_xformers_operator
+    # from xformers.ops.common import get_xformers_operator
 
-    try:
-        get_xformers_operator("swiglu_packedw")()
-        return True
-    except RuntimeError as exc:
-        if "No such operator xformers::swiglu_packedw " in str(exc):
-            return False
-        return True
+    # try:
+    #     get_xformers_operator("swiglu_packedw")()
+    #     return True
+    # except RuntimeError as exc:
+    #     if "No such operator xformers::swiglu_packedw " in str(exc):
+    #         return False
+    #     return True
+    return False
 
 
 def replace_llama_mlp_with_swiglu(model):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Modifying Axolotl to work on ROCm, following Eric's guide: https://erichartford.com/from-zero-to-fineturning-with-axolotl-on-rocm

<!--- Describe your changes in detail -->

Removed dependencies on bitsandbytes, accelerate, DeepSpeed, flash-attention2, and xformers.
Edited setup.py and src/axolotl/monkeypatch/llama_attn_hijack_flash.py to remove references to xformers.

<!--- Why is this change required? What problem does it solve? -->

Solves issue of Axolotl running on ROCm, in conjunction with other changes to the libraries listed above to ensure they work with ROCm.

## How has this been tested?

Successfully ran fine-tuning in container

